### PR TITLE
Add a function to parse and evaluate an expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,13 +146,37 @@ user	0m0.369s
 sys	0m0.300s
 ```
 
+# Evaluate an expression on the server
+
+Alternatively, a String can be passed to the server which is then parsed and evaluated in its global scope.
+
+```julia
+using DaemonTools
+
+runexpr("using CSV, DataFrames")
+
+fname = "tsp_50.csv";
+
+runexpr("""begin
+      df = CSV.File("$fname") |> DataFrame
+      println(last(df, 3))
+  end""")
+3×2 DataFrames.DataFrame
+│ Row │ x        │ y          │
+│     │ Float64  │ Float64    │
+├─────┼──────────┼────────────┤
+│ 1   │ 0.420169 │ 0.628786   │
+│ 2   │ 0.892219 │ 0.673288   │
+│ 3   │ 0.530688 │ 0.00151249 │
+```
+
 # Features
 
 - [X] Performance, because the packages is maintained in memory. This is specially interesting with common external packages like CSV.jl, DataFrames, ...
 
 - [X] The code is run using the current directory as working directory.
 
-- [X] Robust, if the file have an error, the server continue working.
+- [X] Robust, if the file have an error, the server continues working.
 
 - [X] It accept parameters without problem.
 

--- a/src/DaemonMode.jl
+++ b/src/DaemonMode.jl
@@ -21,26 +21,26 @@ function serve(port=PORT)
         sock = accept(server)
         mode = readline(sock)
         
-        (_, old) = redirect_stdout()
-        redirect_stdout(sock)
-        (_, old_error) = redirect_stderr()
-        redirect_stderr(sock)
+        redirect_stdout(sock) do
+            redirect_stderr(sock) do
+        
+                if mode == "runFile()"
+                    serverRunFile(sock)
+                elseif mode == "runExpr()"
+                    serverRunExpr(sock)
+                elseif mode == "exit()"
+                    println(sock, token_end)
+                    sleep(1)
+                    quit = true
+                else
+                    println(sock, "Error, unrecognised mode, expected (\"runFile()\", \"runExpr()\" or \"exit()\", but received \"$mode\"")
+                end
 
-        if mode == "runFile()"
-            serverRunFile(sock)
-        elseif mode == "runExpr()"
-            serverRunExpr(sock)
-        elseif mode == "exit()"
-            println(sock, token_end)
-            sleep(1)
-            quit = true
-        else
-            println(sock, "Error, unrecognised mode, expected (\"runFile()\", \"runExpr()\" or \"exit()\", but received \"$mode\"")
+            end
         end
 
-        redirect_stdout(old)
-        redirect_stderr(old_error)
     end
+    close(server)
 end
 
 function serverRunFile(sock)
@@ -129,7 +129,6 @@ function runfile(fname::AbstractString; args=String[], port=port, output=stdout)
     else
         fcompletename = fname
     end
-
     try
         sock = Sockets.connect(port)
         println(sock, "runFile()")

--- a/src/DaemonMode.jl
+++ b/src/DaemonMode.jl
@@ -103,7 +103,7 @@ function serverRunExpr(sock)
     empty!(ARGS)
 end
 
-function runexpr(expr::AbstractString, output = stdout, port = PORT)
+function runexpr(expr::AbstractString ; output = stdout, port = PORT)
     try
         sock = Sockets.connect(port)
         println(sock, "runExpr()")
@@ -121,7 +121,7 @@ function runexpr(expr::AbstractString, output = stdout, port = PORT)
     end
 end
 
-function runfile(fname::AbstractString; args=String[], port=port, output=stdout)
+function runfile(fname::AbstractString; args=String[], port = PORT, output=stdout)
     dir = dirname(fname)
 
     if isempty(dir)

--- a/src/DaemonMode.jl
+++ b/src/DaemonMode.jl
@@ -1,5 +1,7 @@
 module DaemonMode
 
+export serve, runfile, runargs, runexpr, sendExitCode
+
 using Sockets
 
 const PORT = 3000
@@ -7,81 +9,119 @@ const PORT = 3000
 function add_packages(fname::AbstractString)
 end
 
-const first_time = [true]
+const first_time = Ref(true)
 const token_end = "DaemonMode::Exit"
 
 function serve(port=PORT)
     server = Sockets.listen(Sockets.localhost, port)
-    global first_time
-    global token_end
     quit = false
     current = pwd()
 
     while !quit
         sock = accept(server)
-        dir = readline(sock)
-        fname = readline(sock)
-        args_str = readline(sock)
-        args = split(args_str, " ")
-
-        for arg in args
-            push!(ARGS, arg)
-        end
-
-        first_time .= true
-        cd(current)
-
-        if (fname == "exit()")
-            println(sock, token_end)
-            sleep(1)
-            quit = true
-            continue
-        end
-
+        mode = readline(sock)
+        
         (_, old) = redirect_stdout()
         redirect_stdout(sock)
         (_, old_error) = redirect_stderr()
         redirect_stderr(sock)
-        error = ""
 
-        try
-            cd(dir)
-            include(joinpath(dir, fname))
-        catch e
-            if isa(e, LoadError)
-                if :msg in propertynames(e.error)
-                    error_msg = e.error.msg
-                else
-                    error_msg = "$e.error"
-                end
-
-                error = "ERROR in line $(e.line): '$(error_msg)'"
-            else
-                error = "ERROR: could not open file '$fname'"
-            end
-        end
-
-        while !isempty(ARGS)
-            pop!(ARGS)
+        if mode == "runFile()"
+            serverRunFile(sock)
+        elseif mode == "runExpr()"
+            serverRunExpr(sock)
+        elseif mode == "exit()"
+            println(sock, token_end)
+            sleep(1)
+            quit = true
+        else
+            println(sock, "Error, unrecognised mode, expected (\"runFile()\", \"runExpr()\" or \"exit()\", but received \"$mode\"")
         end
 
         redirect_stdout(old)
         redirect_stderr(old_error)
+    end
+end
 
-        if !isempty(error)
-            println(sock, error)
+function serverRunFile(sock)
+    dir = readline(sock)
+    fname = readline(sock)
+    args_str = readline(sock)
+    args = split(args_str, " ")
+
+    append!(ARGS, args)
+
+    first_time[] = true
+    error = ""
+
+    try
+        cd(dir) do 
+            include(joinpath(dir, fname))
+        end
+    catch e
+        if isa(e, LoadError)
+            if :msg in propertynames(e.error)
+                error_msg = e.error.msg
+            else
+                error_msg = "$(e.error)"
+            end
+            error = "ERROR in line $(e.line): '$(error_msg)'"
+        else
+            error = "ERROR: could not open file '$fname'"
+        end
+    end
+
+    !isempty(error) && println(sock, error)
+    println(sock, token_end)
+    empty!(ARGS)
+end
+
+function serverRunExpr(sock)
+    dir = readline(sock)
+    expr = readline(sock)
+    error = ""
+
+    try
+        cd(dir) do 
+            Main.eval(Meta.parse(expr))
+        end
+    catch e
+        if isa(e, LoadError)
+            if :msg in propertynames(e.error)
+                error_msg = e.error.msg
+            else
+                error_msg = "$(e.error)"
+            end
+            error = "ERROR in line $(e.line): '$(error_msg)'"
+        else
+            error = "ERROR: $e"
+        end
+    end
+
+    !isempty(error) && println(sock, error)
+    println(sock, token_end)
+    empty!(ARGS)
+end
+
+function runexpr(expr::AbstractString, output = stdout, port = PORT)
+    try
+        sock = Sockets.connect(port)
+        println(sock, "runExpr()")
+        println(sock, pwd())
+        println(sock, expr)
+
+        line = readline(sock)
+        while (line != token_end)
+            println(output, line)
+            line = readline(sock)
         end
 
-        println(sock, token_end)
-
-        while !isempty(ARGS)
-            pop!(ARGS)
-        end
+    catch e
+        println(stderr, "Error, cannot connect with server. Is it running?")
     end
 end
 
 function runfile(fname::AbstractString; args=String[], port=port, output=stdout)
-    global token_end
     dir = dirname(fname)
 
     if isempty(dir)
@@ -92,19 +132,24 @@ function runfile(fname::AbstractString; args=String[], port=port, output=stdout)
 
     try
         sock = Sockets.connect(port)
+        println(sock, "runFile()")
         println(sock, pwd())
         println(sock, fcompletename)
         println(sock, join(args, " "))
         line = readline(sock)
-
         while (line != token_end)
             println(output, line)
             line = readline(sock)
         end
     catch e
-        println(stderr, "Error, cannot connected with server. It is running?")
+        println(stderr, "Error, cannot connect with server. Is it running?")
     end
     return
+end
+
+function sendExitCode(port = PORT)
+    sock = Sockets.connect(port)
+    println(sock, "exit()")
 end
 
 function runargs(port=PORT)
@@ -114,8 +159,5 @@ function runargs(port=PORT)
     runfile(ARGS[1], args=ARGS[2:end], port=port)
 end
 
-export serve
-export runfile
-export runargs
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,12 +5,14 @@ using Sockets
 @testset "Start Server" begin
     @test_throws Base.IOError connect(3000)
     task = @async serve()
+    sleep(1)
     sendExitCode()
     wait(task)
 end
 
 @testset "runFile" begin
     task = @async serve()
+    sleep(1)
     buffer = IOBuffer()
     files = ["hello.jl", "hello2.jl"]
     outputs = ["Hello, World!\n", "Hello, World\n\nBye, World!\n"]
@@ -28,6 +30,7 @@ end
 
 @testset "runExpr" begin
     task = @async serve()
+    sleep(1)
     buffer = IOBuffer()
     expr = "x = 3 ; for i = 1:x ; println(i) ; end"
     runexpr(expr, output=buffer)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,11 +31,25 @@ end
 @testset "runExpr" begin
     task = @async serve()
     sleep(1)
+
     buffer = IOBuffer()
     expr = "x = 3 ; for i = 1:x ; println(i) ; end"
     runexpr(expr, output=buffer)
     output = String(take!(buffer))
     @test output == "1\n2\n3\n"
+
+
+    buffer = IOBuffer()
+    expr = "begin
+        x = 2
+        for i = 1:2
+            println(i)
+        end
+    end"
+    runexpr(expr, output=buffer)
+    output = String(take!(buffer))
+    @test output == "1\n2\n"
+
     sendExitCode()
     wait(task)
 end


### PR DESCRIPTION
This PR adds the function `runexpr` which passes forward a string to the host, which is then parsed and evaluated on the server.

e.g. : `runexpr("x = 3 ; for i = 1:x ; println(i) ; end", output=buffer)`

I reorganized the code to handle running a file versus running an expression on the server and the first thing the server reads is now the mode, which can be `token_runfile`, `token_runexpr` or `token_exit`.
Exiting the server is now done by the function `sendExitCode()`.

I had a few issues when trying to add a test and resolved it by closing the connection before leaving the function `serve()`
