### PR TITLE
[WIP] Ignore EPIPE when replying error to client

### DIFF
--- a/src/DaemonMode.jl
+++ b/src/DaemonMode.jl
@@ -103,8 +103,16 @@ function serverRunFile(sock, shared)
         end
     end
 
-    !isempty(error) && println(sock, error)
-    println(sock, token_end)
+    try
+        !isempty(error) && println(sock, error)
+        println(sock, token_end)
+    catch e
+        if (e isa Base.IOError) && abs(e.code) == abs(Libc.EPIPE)
+            # client disconnected early, ignore
+        else
+            rethrow()
+        end
+    end
     empty!(ARGS)
 end
 


### PR DESCRIPTION
If a script produces too many output and I hit ^C on the client side, the server will exit on unhandled EPIPE.  I guess I'd better change `serverRunExpr` together, but I'm not sure what is that `m = Model()` in it?