### PR TITLE
Fix error handling in serverRunExpr

### DIFF
--- a/src/DaemonMode.jl
+++ b/src/DaemonMode.jl
@@ -214,7 +214,7 @@ function serverRunExpr(sock, shared, print_stack)
     try
         dir = readline(sock)
         expr = readuntil(sock, token_end) # Read until token_end to handle multi-line expressions
-        parsedExpr = Meta.parse(expr)
+        parsedExpr = Meta.parse(strip(expr))
 
         cd(dir) do
             serverRun(sock, shared, print_stack, "") do mod

--- a/src/DaemonMode.jl
+++ b/src/DaemonMode.jl
@@ -172,7 +172,7 @@ function serverRunExpr(sock, shared, print_stack)
             end
         end
     catch e
-        serverReplyError(e)
+        serverReplyError(sock,e)
     end
 
     empty!(ARGS)

--- a/src/DaemonMode.jl
+++ b/src/DaemonMode.jl
@@ -197,7 +197,7 @@ function runexpr(expr::AbstractString ; output = stdout, port = PORT)
         sock = Sockets.connect(port)
         println(sock, token_runexpr)
         println(sock, pwd())
-        println(sock, expr)
+        println(sock, strip(expr))
         println(sock, token_end)
 
         line = readline(sock)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,7 +53,12 @@ end
     output = String(take!(buffer))
     @test output == "1\n2\n"
 
-    expr = "begin end\n\n"
+    expr = "begin 
+        x = 2
+        for i = 1:2
+            println(i)
+        end
+    end\n\n"
     # @test Meta.parse(expr)
 
     runexpr(expr, output=buffer, port=port)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,6 +53,19 @@ end
     output = String(take!(buffer))
     @test output == "1\n2\n"
 
+    expr = """
+    begin
+        x = 2
+        for i = 1:2
+            println(i)
+        end
+    end
+
+    """
+    runexpr(expr, output=buffer, port=port)
+    output = String(take!(buffer))
+    @test output == "1\n2\n"
+
     sendExitCode(port)
     wait(task)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,8 +58,9 @@ end
         for i = 1:2
             println(i)
         end
-    end\n\n"
-    # @test Meta.parse(expr)
+    end
+    
+    "
 
     runexpr(expr, output=buffer, port=port)
     output = String(take!(buffer))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,18 +53,13 @@ end
     output = String(take!(buffer))
     @test output == "1\n2\n"
 
-    expr = """
-    begin
-        x = 2
-        for i = 1:2
-            println(i)
-        end
-    end
+    expr = "begin end\n\n"
+    # @test Meta.parse(expr)
 
-    """
     runexpr(expr, output=buffer, port=port)
     output = String(take!(buffer))
     @test output == "1\n2\n"
+    @test istaskdone(task) == false
 
     sendExitCode(port)
     wait(task)


### PR DESCRIPTION
* ~~Fix  serverReplyError(sock,e) call - fixes #16~~ - done by upstream
* Strip `expr` to avoid parsing errors on multiple trailing newlines
* Extended the `runexpr` testset
* Meta.parse only works for a single top level expression.
  *  https://discourse.julialang.org/t/meta-parse-failes-on-double-newlines/54272
  * Maybe Meta.parse(...,1) would be a better solution