### PR TITLE
add builtin Revise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,19 +252,11 @@ to the server, so each time the codes are updated, you would
 get the up-to-date results. However, sometimes you may also
 be developing some packages in the same time, and want they
 got reloaded when modified. You can use Revise together with
-DaemonMode for this purpose.
-
-- First, you need to load Revise at the server:
+DaemonMode for this purpose. You only need to add `using
+Revise`, before starting the DaemonMode server:
 
 ```julia
 julia --startup-file=no -e 'using Revise; using DaemonMode; serve()'
-```
-
-- Then, you need to notify Revise before sending the codes
-  at the client:
-
-```julia
-julia --startup-file=no -e "using DaemonMode; runexpr(\"using Revise; Revise.revise()\"); runargs()" program.jl <arguments>
 ```
 
 # Features

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -307,17 +307,9 @@ to the server, so each time the codes are updated, you would
 get the up-to-date results. However, sometimes you may also
 be developing some packages in the same time, and want they
 got reloaded when modified. You can use Revise together with
-DaemonMode for this purpose.
-
-- First, you need to load Revise at the server:
+DaemonMode for this purpose. You only need to add `using
+Revise`, before starting the DaemonMode server:
 
 ```julia
 julia --startup-file=no -e 'using Revise; using DaemonMode; serve()'
-```
-
-- Then, you need to notify Revise before sending the codes
-  at the client:
-
-```julia
-julia --startup-file=no -e "using DaemonMode; runexpr(\"using Revise; Revise.revise()\"); runargs()" program.jl <arguments>
 ```


### PR DESCRIPTION
Now, the users only need to use Revise before start the server. No other operation is needed.
DaemonMode has been benefiting my own works a lot, hope this PR could make it more beneficial and practical.

BTW, maybe executing `Revise.revise()` also regularly instead of executing it only before codes are sent to the server could make the experiences even better, but I do not have much time to verify this idea.