### PR TITLE
Make DaemonMode aware of which script file is currently running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 /Manifest.toml
 /dev/
+/test/*.log

--- a/test/fileandline.jl
+++ b/test/fileandline.jl
@@ -1,0 +1,7 @@
+println(@__FILE__)
+#=
+    To truly test @__LINE__
+    I add a couple comments
+    Seven is random
+=#
+println(@__LINE__)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,6 +181,6 @@ end
 @testset "testCodeloc" begin
     output = test_evalfile("fileandline.jl", port=3011)
     l = split(output)
-    @test endswith(l[1], "/test/fileandline.jl")
+    @test endswith(l[1], joinpath("test", "fileandline.jl"))
     @test l[2] == "7"
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,13 +90,13 @@ end
     output = String(take!(buffer))
     @test output == "1\n2\n"
 
-    expr = "begin 
+    expr = "begin
         x = 2
         for i = 1:2
             println(i)
         end
     end
-    
+
     "
 
     runexpr(expr, output=buffer, port=port)
@@ -176,4 +176,11 @@ end
 @testset "testEval" begin
     output = test_evalfile("eval.jl", port=3010)
     @test output == "3\n"
+end
+
+@testset "testCodeloc" begin
+    output = test_evalfile("fileandline.jl", port=3011)
+    l = split(output)
+    @test endswith(l[1], "/test/fileandline.jl")
+    @test l[2] == "7"
 end


### PR DESCRIPTION
I needed `@__FILE__` and potentially `@__LINE__`, but DaemonMode treated input files as a string (#42).
I needed to remove the lines marked as "Following code not needed", but this caused no test errors so.