### PR TITLE
Fix async connection handling in sendExitCode by re-sending client en…

### DIFF
--- a/src/DaemonMode.jl
+++ b/src/DaemonMode.jl
@@ -594,6 +594,7 @@ function sendExitCode(port=PORT)
         # For async it is need to create a new connection
         try
             sock = Sockets.connect(port)
+            println(sock, token_client_end)
         catch e
         end
     end


### PR DESCRIPTION
In daemon mode, the sendExitCode function handles both sync and async server responses. The async case requires a new socket connection to complete the shutdown handshake. Previously, the token token_client_end was not sent on this new connection, which could lead to an incomplete or hanging shutdown process.

This change ensures that after reconnecting for the async case, we send token_client_end again on the new socket. This completes the protocol as intended.

Tested and verified that without this second token send, the async shutdown doesn't finalize properly.