### PR TITLE
Fix logging color

### DIFF
--- a/src/DaemonMode.jl
+++ b/src/DaemonMode.jl
@@ -243,7 +243,7 @@ function create_mylog(fname)
             file = joinpath(pwd(), fname)
         end
 
-        println(io, color, "└ ", Crayon(foreground=:dark_gray), "@ ", module_str, " ", file, ": ", args.line)
+        println(io, color, "└ ", Crayon(foreground=:dark_gray), "@ ", module_str, " ", file, ": ", args.line, reset)
     end
 end
 


### PR DESCRIPTION
There is probably a color reset forgotten when logging the module location and line number. Without it, any following uncolored output will become dark gray.